### PR TITLE
Allow data param optional match to boolean

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -172,7 +172,7 @@ class Logger {
       method[`${this.prefix}_logger_emit_${name}`] = function (level, message, data, userId) {
         check(level, String);
         check(message, Match.Optional(Match.OneOf(Number, String, null)));
-        check(data, Match.Optional(Match.OneOf(String, Object, null)));
+        check(data, Match.Optional(Match.OneOf(String, Object, Boolean, null)));
         check(userId, Match.Optional(Match.OneOf(String, Number, null)));
         emitter(level, message, data, (userId || this.userId));
       };


### PR DESCRIPTION
Please see [this issue](https://github.com/VeliovGroup/Meteor-logger/issues/11).

Log calls where data param is omitted or the object is empty currently causes error.

This PR simply allows boolean values to pass existing the match checks as the current behaviour results in omitted or empty data params to be falsey and therefore invalid.


Thanks,
Dan