### PR TITLE
Void circular references in data object parameter

### DIFF
--- a/logger-tests.js
+++ b/logger-tests.js
@@ -147,7 +147,7 @@ Tinytest.add('LoggerMessage#toString', (test) => {
   test.equal(log.fatal('This is message "fatal"', {data: 'Sample data "fatal"'}, 'userId "fatal"').toString(), '[This is message "fatal"] \nLevel: FATAL; \nDetails: {"data":"Sample data \\"fatal\\""}; \nUserId: userId "fatal";');
   test.equal(log.warn('This is message "warn"', {data: 'Sample data "warn"'}, 'userId "warn"').toString(), '[This is message "warn"] \nLevel: WARN; \nDetails: {"data":"Sample data \\"warn\\""}; \nUserId: userId "warn";');
   test.equal(log._('This is message "_"', {data: 'Sample data "_"'}, 'userId "_"').toString(), '[This is message "_"] \nLevel: LOG; \nDetails: {"data":"Sample data \\"_\\""}; \nUserId: userId "_";');
-  test.equal(log.info('This is message "info", with circular data', circular, 'userId "info"').toString(), '[This is message "info", with circular data] \nLevel: INFO; \nDetails: {"desc":"Circular data example"}; \nUserId: userId "info";');
+  test.equal(log.info('This is message "info", with circular data', circular, 'userId "info"').toString(), '[This is message "info", with circular data] \nLevel: INFO; \nDetails: {"desc":"Circular data example","circular":"[Circular]"}; \nUserId: userId "info";');
 });
 
 Tinytest.add('Logger Client Only', (test) => {
@@ -201,4 +201,8 @@ Tinytest.add('Log a Number', (test) => {
 Tinytest.add('Trace', (test) => {
   test.isTrue(_.has(log.trace(60, {data: 60}, 60).details, 'stackTrace'));
   test.isTrue(_.has(log.trace(60, {data: 60}, 60).data, 'stackTrace'));
+});
+
+Tinytest.add('Logger#antiCircular', (test) => {
+  test.equal(Logger.prototype.antiCircular(circular), { 'desc': 'Circular data example', 'circular': '[Circular]' });
 });

--- a/logger-tests.js
+++ b/logger-tests.js
@@ -15,6 +15,9 @@ const logs = {
   NowhereAdapter: false
 };
 
+const circular = { desc: 'Circular data example' };
+circular.circular = circular;
+
 const log = new Logger();
 const testEmitter = () => {
   return;
@@ -128,6 +131,7 @@ Tinytest.add('LoggerMessage Instance', (test) => {
   test.instanceOf(log.warn('This is message "warn"', {data: 'Sample data "warn"'}, 'userId "warn"'), LoggerMessage);
   test.instanceOf(log.trace('This is message "trace"', {data: 'Sample data "trace"'}, 'userId "trace"'), LoggerMessage);
   test.instanceOf(log._('This is message "_"', {data: 'Sample data "_"'}, 'userId "_"'), LoggerMessage);
+  test.instanceOf(log.info('This is message "info", with circular data', circular, 'userId "info"'), LoggerMessage);
 });
 
 Tinytest.add('LoggerMessage#toString', (test) => {
@@ -143,26 +147,27 @@ Tinytest.add('LoggerMessage#toString', (test) => {
   test.equal(log.fatal('This is message "fatal"', {data: 'Sample data "fatal"'}, 'userId "fatal"').toString(), '[This is message "fatal"] \nLevel: FATAL; \nDetails: {"data":"Sample data \\"fatal\\""}; \nUserId: userId "fatal";');
   test.equal(log.warn('This is message "warn"', {data: 'Sample data "warn"'}, 'userId "warn"').toString(), '[This is message "warn"] \nLevel: WARN; \nDetails: {"data":"Sample data \\"warn\\""}; \nUserId: userId "warn";');
   test.equal(log._('This is message "_"', {data: 'Sample data "_"'}, 'userId "_"').toString(), '[This is message "_"] \nLevel: LOG; \nDetails: {"data":"Sample data \\"_\\""}; \nUserId: userId "_";');
+  test.equal(log.info('This is message "info", with circular data', circular, 'userId "info"').toString(), '[This is message "info", with circular data] \nLevel: INFO; \nDetails: {"desc":"Circular data example"}; \nUserId: userId "info";');
 });
 
 Tinytest.add('Logger Client Only', (test) => {
   if (Meteor.isServer) {
     test.equal(logs.client.length, 0);
   } else {
-    test.equal(logs.client.length, 6);
+    test.equal(logs.client.length, 7);
   }
 });
 
 Tinytest.add('Logger Server Only', (test) => {
   if (Meteor.isServer) {
-    test.equal(logs.server.length, 6);
+    test.equal(logs.server.length, 7);
   } else {
     test.equal(logs.server.length, 0);
   }
 });
 
 Tinytest.add('Logger Isomorphic', (test) => {
-  test.equal(logs.both.length, 6);
+  test.equal(logs.both.length, 7);
 });
 
 Tinytest.add('Logger Nowhere', (test) => {

--- a/logger.js
+++ b/logger.js
@@ -41,7 +41,9 @@ class Logger {
    */
   _log(level, message, _data = {}, user) {
     const uid = user || this.userId.get();
-    let data = _data;
+
+    // sanitize circular refs before passing to emitters
+    let data = Logger.prototype.antiCircular(_data);
 
     for (let i in this._emitters) {
       if (this._rules[this._emitters[i].name] && this._rules[this._emitters[i].name].enable === true) {
@@ -219,23 +221,19 @@ class Logger {
    * @param data {Object} - Circular or any other object which needs to be non-circular
    */
   antiCircular(obj) {
-    const _cache = [];
-    const _wrap = (o) => {
-      for (let v in o) {
-        if (v !== null && typeof v === 'object') {
-          if (_cache.indexOf(v) !== -1) {
-            o[o[v]] = '[Circular]';
-            break;
-          }
-          _cache.push(v);
-          _wrap(v);
-          break;
+    const cache = new Map();
+    return JSON.parse(JSON.stringify(obj, function (key, value) {
+      if (typeof value === 'object' && value !== null) {
+        if (cache.get(value)) {
+          // circular reference found, void it
+          obj[key] = '[Circular]';
+          return;
         }
+        // store value in our map
+        cache.set(value, true);
       }
-    };
-
-    _wrap(obj);
-    return obj;
+      return value;
+    }));
   }
 
   /*
@@ -286,7 +284,7 @@ class LoggerMessage {
     this.message = data.message;
 
     this.toString = () => {
-      return `[${this.reason}] \nLevel: ${this.level}; \nDetails: ${JSON.stringify(Logger.prototype.antiCircular(this.data))}; \nUserId: ${this.userId};`;
+      return `[${this.reason}] \nLevel: ${this.level}; \nDetails: ${JSON.stringify(this.data)}; \nUserId: ${this.userId};`;
     };
   }
 }


### PR DESCRIPTION
As outlined in #15, logger fails with error if the data param contains circular references.

This PR adds units tests to highlight this condition, and an updated `antiCircular` function to demonstrate expected behaviour.