### PR TITLE
Fix Logger.antiCircular function to prevent object mutation

### DIFF
--- a/logger-tests.js
+++ b/logger-tests.js
@@ -205,4 +205,5 @@ Tinytest.add('Trace', (test) => {
 
 Tinytest.add('Logger#antiCircular', (test) => {
   test.equal(Logger.prototype.antiCircular(circular), { 'desc': 'Circular data example', 'circular': '[Circular]' });
+  test.equal(circular.circular.desc, 'Circular data example');
 });

--- a/logger.js
+++ b/logger.js
@@ -260,20 +260,25 @@ class Logger {
    * @param data {Object} - Circular or any other object which needs to be non-circular
    */
   antiCircular(obj) {
-    const cache = new Map();
-    return JSON.parse(JSON.stringify(obj, function (key, value) {
-      if (typeof value === 'object' && value !== null) {
-        if (cache.get(value)) {
-          // circular reference found, void it
-          obj[key] = '[Circular]';
-          return void 0;
+    return JSON.parse(JSON.stringify(obj, this._getCircularReplacer()));
+  }
+
+  /*
+   * @memberOf Logger
+   * @name getCircularReplacer
+   */
+  _getCircularReplacer() {
+    const seen = new WeakSet();
+    return (key, value) => {
+      if (typeof value === "object" && value !== null) {
+        if (seen.has(value)) {
+          return '[Circular]';
         }
-        // store value in our map
-        cache.set(value, true);
+        seen.add(value);
       }
       return value;
-    }));
-  }
+    };
+  };
 
   /*
    * @memberOf Logger


### PR DESCRIPTION
Hi.

A [previous PR](https://github.com/VeliovGroup/Meteor-logger/pull/16) inadvertently introduced a pretty nasty bug. 
The `antiCircular` function actually **mutates the original object** when there are circular references.

This PR addresses the issue. For reference; the circular replacer function has been derived from:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Cyclic_object_value#Examples


Thanks,
Dan